### PR TITLE
feat: licenseheader

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -83,6 +83,9 @@ jobs:
       - name: Check susp
         run: make govet
 
+      - name: Check licenseheader
+        run: make check-licensehead
+
       - name: Compilecheck
         run: make compilecheck
 

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,108 @@
 include ./Makefile.Common
 
-#RULES
+# Rules
 $(TOOLS_DIR):
 	mkdir -p $@
 
+# Funcs
+
+.PHONY: check-fmt
 check-fmt: gofmt
 	@git diff -s --exit-code *.go || (echo "Build failed: a go file is not formated correctly. Run 'make fmt' and update your PR." && exit 1)
 
+.PHONY: gofmt
 gofmt:
 	go fmt ./...
 
+.PHONY: govet
 govet:
 	go vet ./...
 
+.PHONY: build
 build:
 	go build -v -o $(LETS_PARTY) $(ROOT_DIR)/cmd/server/main.go
 
+.PHONY: compilecheck
 compilecheck:
 	$(GO_ENV)
 	go build -v ./...
 
+.PHONY: run
 run: gofmt build
 	$(LETS_PARTY)
 
+.PHONY: gotest
 gotest: 
 	$(GO_ENV)
 	go test -v ./... -failfast
 
+.PHONY: localtest
 localtest: gofmt govet check-fmt
 	$(GO_ENV)
 	go test -v ./... -failfast
 
+.PHONY: gomoddownload
 gomoddownload:
 	go mod download -x
 
+.PHONY: install-gotools
 install-gotools: $(TOOLS_DIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_DIR) $(GOLINT_VERSION) 
 
+.PHONY: golint
 golint:
 	$(LINT) run --verbose --allow-parallel-runners --timeout=10m 
 
+.PHONY: gotidy
 gotidy:
 	go mod tidy -compat=$(GO_VERSION)
+
+.PHONY: check-licensehead
+check-licensehead:
+	@for f in $(ALL_GO_FILES); do \
+			first_line=$$(sed -n '1p' "$$f"); \
+			second_line=$$(sed -n '2p' "$$f"); \
+			if [ "$$first_line" != "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" != "$(LICENSEHEAD_SECOND_LINE)" ]; then \
+				echo "Error: License header mismatch in $$f"; \
+				exit 1; \
+			else \
+				echo "Check: License header checked in $$f"; \
+			fi \
+		done; \
+		echo "License headers checked successfully."
+
+.PHONY: licensehead
+licensehead:
+	@for f in $(ALL_GO_FILES); do \
+			first_line=$$(sed -n '1p' "$$f"); \
+			second_line=$$(sed -n '2p' "$$f"); \
+			if [ "$$first_line" != "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" != "$(LICENSEHEAD_SECOND_LINE)" ]; then \
+				echo "Found: License header mismatch in $$f"; \
+				sed -i "1i$(LICENSEHEAD_FIRST_LINE)" "$$f"; \
+				sed -i "2i$(LICENSEHEAD_SECOND_LINE)\n" "$$f"; \
+				echo "Written: License header written in $$f"; \
+			else \
+				echo "Check: License header checked in $$f"; \
+			fi \
+		done; \
+		echo "License headers written successfully."
+
+.PHONY: deletehead
+deletehead:
+	@for f in $(ALL_GO_FILES); do \
+			first_line=$$(sed -n '1p' "$$f"); \
+			second_line=$$(sed -n '2p' "$$f"); \
+			third_line=$$(sed -n '3p' "$$f"); \
+			if [ -z "$$third_line"] && ([ "$$first_line" == "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" == "$(LICENSEHEAD_SECOND_LINE)" ]); then \
+				echo "Found: License header to delete in $$f"; \
+				sed -i '1,3d' "$$f"; \
+				echo "Deleted: License header deleted in $$f"; \
+			elif [ "$$first_line" == "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" == "$(LICENSEHEAD_SECOND_LINE)" ]; then \
+				echo "Found: License header to delete in $$f"; \
+				sed -i '1,2d' "$$f"; \
+				echo "Deleted: License header deleted in $$f"; \
+			else \
+				echo "Not found: License header not found in $$f"; \
+			fi; \
+		done; \
+		echo "License headers deleted successfully."

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ check-licensehead:
 		echo "License headers checked successfully."
 
 .PHONY: licensehead
-licensehead:
+licensehead: deletehead
 	@for f in $(ALL_GO_FILES); do \
 			first_line=$$(sed -n '1p' "$$f"); \
 			second_line=$$(sed -n '2p' "$$f"); \

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -1,9 +1,12 @@
-#Set directory paths
+# Set directory paths
 ROOT_DIR=$(shell git rev-parse --show-toplevel)
 TOOLS_DIR=$(ROOT_DIR)/.tools
 LETS_PARTY := $(ROOT_DIR)/bin/lets-party
 
-#Set tool-paths for easier access
+# Returns all .go-files
+ALL_GO_FILES=$(shell find $(ROOT_DIR) -type f -name "*.go")
+
+# Set tool-paths for easier access
 LINT := $(TOOLS_DIR)/golangci-lint
 
 # Env vars
@@ -12,3 +15,8 @@ GO_ENV=$(shell CGO_ENABLED=0)
 # Versioning
 GO_VERSION=1.21
 GOLINT_VERSION=v1.57.2
+
+# Licenseheader
+LICENSEHEAD_FIRST_LINE := // Copyright (C) 2024 the lets-party maintainers
+LICENSEHEAD_SECOND_LINE := // See root-dir/LICENSE for more information
+

--- a/cmd/convert/main.go
+++ b/cmd/convert/main.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package main
 
 import (

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package main
 
 import (

--- a/intern/db/event_store.go
+++ b/intern/db/event_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package db
 
 import (

--- a/intern/db/guest_store.go
+++ b/intern/db/guest_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package db
 
 import (

--- a/intern/db/invitation_store.go
+++ b/intern/db/invitation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package db
 
 import (

--- a/intern/db/jsondb/event_store.go
+++ b/intern/db/jsondb/event_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package jsondb
 
 import (

--- a/intern/db/jsondb/guest_store.go
+++ b/intern/db/jsondb/guest_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package jsondb
 
 import (

--- a/intern/db/jsondb/invitation_store.go
+++ b/intern/db/jsondb/invitation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package jsondb
 
 import (

--- a/intern/db/jsondb/tracing.go
+++ b/intern/db/jsondb/tracing.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package jsondb
 
 import "go.opentelemetry.io/otel"

--- a/intern/db/jsondb/translation_store.go
+++ b/intern/db/jsondb/translation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package jsondb
 
 import (

--- a/intern/db/kvdb/event_store.go
+++ b/intern/db/kvdb/event_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package kvdb
 
 import (

--- a/intern/db/kvdb/guest_store.go
+++ b/intern/db/kvdb/guest_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package kvdb
 
 import (

--- a/intern/db/kvdb/invitation_store.go
+++ b/intern/db/kvdb/invitation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package kvdb
 
 import (

--- a/intern/db/kvdb/tracing.go
+++ b/intern/db/kvdb/tracing.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package kvdb
 
 import "go.opentelemetry.io/otel"

--- a/intern/db/kvdb/translation_store.go
+++ b/intern/db/kvdb/translation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package kvdb
 
 import (

--- a/intern/db/translation_store.go
+++ b/intern/db/translation_store.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package db
 
 import (

--- a/intern/model/event.go
+++ b/intern/model/event.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package model
 
 import (

--- a/intern/model/guest.go
+++ b/intern/model/guest.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package model
 
 import (

--- a/intern/model/invitation.go
+++ b/intern/model/invitation.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package model
 
 import "github.com/google/uuid"

--- a/intern/model/invitation_test.go
+++ b/intern/model/invitation_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package model
 
 import (

--- a/intern/model/translation.go
+++ b/intern/model/translation.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package model
 
 type Translation struct {

--- a/intern/parser/form/form.go
+++ b/intern/parser/form/form.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package form
 
 import (

--- a/intern/server/server.go
+++ b/intern/server/server.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package server
 
 import (

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package templates
 
 import (

--- a/intern/server/templates/tracing.go
+++ b/intern/server/templates/tracing.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package templates
 
 import "go.opentelemetry.io/otel"


### PR DESCRIPTION
According to the GPL-3.0-license we had to add headers to our .go-files.
Therefore i made some changes:
#### Makefile
- added var `ALL_GO_FILES` to collect all .go-files
- added `LICENSEHEAD_FIRST_LINE` & `LICENSEHEAD_SECOND_LINE` so we can make changes to headers globally
- added `licensehead` function which scans for existing licenseheaders (provided by the vars) and if it doesn't match adds the provided licenseheader to the called file
- added `check-licensehead` function which scans files in first 2 lines to check if they match  the provided vars
- added `deletehead` function which scans for existing licenseheaders (provided by the vars & optional a placeholder-line) and deletes if it matches

#### Workflow
- added step `check-licensehead` to build-and-test

now as i'm writing this i think it would be a good idea to run the `deletehead` function before running `licensehead`, so in case s.o. just want to change the header it doesn't get messy
