### PR TITLE
fix: Makefile deletehead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,19 +90,15 @@ licensehead: deletehead
 .PHONY: deletehead
 deletehead:
 	@for f in $(ALL_GO_FILES); do \
-			first_line=$$(sed -n '1p' "$$f"); \
-			second_line=$$(sed -n '2p' "$$f"); \
-			third_line=$$(sed -n '3p' "$$f"); \
-			if [ -z "$$third_line"] && ([ "$$first_line" == "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" == "$(LICENSEHEAD_SECOND_LINE)" ]); then \
-				echo "Found: License header to delete in $$f"; \
-				sed -i '1,3d' "$$f"; \
-				echo "Deleted: License header deleted in $$f"; \
-			elif [ "$$first_line" == "$(LICENSEHEAD_FIRST_LINE)" ] || [ "$$second_line" == "$(LICENSEHEAD_SECOND_LINE)" ]; then \
-				echo "Found: License header to delete in $$f"; \
-				sed -i '1,2d' "$$f"; \
-				echo "Deleted: License header deleted in $$f"; \
+			if [ "$$(sed -n '1p' "$$f" | grep '^//')" ] && [ "$$(sed -n '2p' "$$f" | grep '^//')" ]; then \
+				if [ -z "$$(sed -n '3p' "$$f")" ]; then \
+					sed -i '1,3d' "$$f"; \
+				else \
+					sed -i '1,2d' "$$f"; \
+				fi; \
+				echo "Deleted: License headers deleted in $$f"; \
 			else \
-				echo "Not found: License header not found in $$f"; \
+				echo "Exit: There were no license headers found in $$f"; \
 			fi; \
 		done; \
 		echo "License headers deleted successfully."


### PR DESCRIPTION
fixes the deletehead method in Makefile:
- before it only deleted the first two lines if it matched the licenseheader (+ third line if its empty) 

- now it deletes the first two lines if they're comment-lines ("//") (+ third line if it's empty)

this was needed because if you're willing to change the header the deletehead method only works if it's matching the current header, but if you already changed it, the method won't work