### PR TITLE
fix: update (hotels&airports)

### DIFF
--- a/intern/model/event.go
+++ b/intern/model/event.go
@@ -17,7 +17,7 @@ type Event struct {
 }
 
 type Location struct {
-	ID           uuid.UUID  `json:"id" form:"-"`
+	ID           uuid.UUID  `json:"id" form:"id"`
 	CreatedAt    *time.Time `json:"created_at" form:"-"`
 	UpdatedAt    *time.Time `json:"updated_at,omitempty" form:"-"`
 	Name         string     `json:"name,omitempty" form:"name"`

--- a/intern/parser/form/form.go
+++ b/intern/parser/form/form.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // Unmarshal parses the url.Values data and stores the result
@@ -93,6 +95,13 @@ func Unmarshal(input url.Values, target any) error {
 			if err := Unmarshal(newInput, fieldVal.Addr().Interface()); err != nil {
 				return err
 			}
+		case reflect.TypeOf(uuid.UUID{}).Kind():
+			if fieldValRaw == "" {
+				continue
+			}
+			parsedUUID := uuid.MustParse(fieldValRaw)
+
+			fieldVal.Set(reflect.ValueOf(parsedUUID))
 		default:
 			panic(fmt.Sprintf("unsupported type: %s", field.Type.String()))
 		}

--- a/intern/parser/form/form.go
+++ b/intern/parser/form/form.go
@@ -65,7 +65,9 @@ func Unmarshal(input url.Values, target any) error {
 				return err
 			}
 			fieldVal.SetFloat(fValue)
+
 		case reflect.Slice:
+			// TODO: needs some work for implementation of prim types
 			sliceValue := reflect.ValueOf(value)
 			for i := 0; i < sliceValue.Len(); i++ {
 				if isPrimitiveType(sliceValue.Type().Elem().Kind()) {
@@ -95,7 +97,7 @@ func Unmarshal(input url.Values, target any) error {
 			if err := Unmarshal(newInput, fieldVal.Addr().Interface()); err != nil {
 				return err
 			}
-		case reflect.TypeOf(uuid.UUID{}).Kind():
+		case reflect.Array:
 			if fieldValRaw == "" {
 				continue
 			}

--- a/intern/parser/form/form_test.go
+++ b/intern/parser/form/form_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 the lets-party maintainers
+// See root-dir/LICENSE for more information
+
 package form
 
 import (

--- a/intern/parser/form/form_test.go
+++ b/intern/parser/form/form_test.go
@@ -1,0 +1,89 @@
+package form
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type TestStruct struct {
+	UUIDField   uuid.UUID   `form:"uuid_field"`
+	StringField string      `form:"string_field"`
+	BoolField   bool        `form:"bool_field"`
+	IntField    int         `form:"int_field"`
+	FloatField  float64     `form:"float_field"`
+	SliceField  []string    `form:"slice_field"`
+	StructField FieldStruct `form:"struct_field"`
+}
+
+type FieldStruct struct {
+	StringField string `form:"field_struct_strfield"`
+	BoolField   bool   `form:"field_struct_boolfield"`
+}
+
+func TestUnmarshal(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       url.Values
+		expected    TestStruct
+		expectedErr bool
+	}{
+		{
+			name: "Valid input data",
+			input: url.Values{
+				"uuid_field":                          {"ca07d617-c87c-4ac3-affc-27a5e941b28f"},
+				"string_field":                        {"test_string"},
+				"bool_field":                          {"true"},
+				"int_field":                           {"42"},
+				"float_field":                         {"3.14"},
+				"slice_field":                         {"1", "2", "3"},
+				"struct_field.field_struct_strfield":  {"stringfield"},
+				"struct_field.field_struct_boolfield": {"true"},
+			},
+			expected: TestStruct{
+				UUIDField:   uuid.MustParse("ca07d617-c87c-4ac3-affc-27a5e941b28f"),
+				StringField: "test_string",
+				BoolField:   true,
+				IntField:    42,
+				FloatField:  3.14,
+				SliceField:  []string{"1", "2", "3"},
+				StructField: FieldStruct{
+					StringField: "stringfield",
+					BoolField:   true,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "Empty input",
+			input:       url.Values{},
+			expected:    TestStruct{},
+			expectedErr: false,
+		},
+		{
+			name: "Missing fields",
+			input: url.Values{
+				"string_field": {"test_string"},
+			},
+			expected: TestStruct{
+				StringField: "test_string",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var target TestStruct
+			err := Unmarshal(tc.input, &target)
+			if (err != nil) != tc.expectedErr {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(target, tc.expected) {
+				t.Errorf("Unmarshal did not produce expected result. got: %+v, expected: %+v", target, tc.expected)
+			}
+		})
+	}
+}

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -864,11 +864,13 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 		for i := 0; i < len(e.Airports); i++ {
 			if lID == e.Airports[i].ID {
 				e.Airports[i] = &l
+				e.Airports[i].ID = lID
 			}
 		}
 		for i := 0; i < len(e.Hotels); i++ {
 			if lID == e.Hotels[i].ID {
 				e.Hotels[i] = &l
+				e.Hotels[i].ID = lID
 			}
 		}
 	}

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -845,6 +845,7 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 		return
 	}
 
+	fmt.Println(raw)
 	for id, ldata := range raw {
 		ldata["id"] = []string{id}
 		l := model.Location{}
@@ -854,7 +855,8 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 			p.logger.ErrorContext(ctx, "could not parse other location", "error", err)
 			continue
 		}
-		lID, err := uuid.Parse(id)
+		var err error
+		l.ID, err = uuid.Parse(id)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "invalid uuid")
@@ -862,15 +864,13 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 			continue
 		}
 		for i := 0; i < len(e.Airports); i++ {
-			if lID == e.Airports[i].ID {
+			if l.ID == e.Airports[i].ID {
 				e.Airports[i] = &l
-				e.Airports[i].ID = lID
 			}
 		}
 		for i := 0; i < len(e.Hotels); i++ {
-			if lID == e.Hotels[i].ID {
+			if l.ID == e.Hotels[i].ID {
 				e.Hotels[i] = &l
-				e.Hotels[i].ID = lID
 			}
 		}
 	}

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -855,6 +855,7 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 			continue
 		}
 		var err error
+		// INFO: workaround(l.ID) until Unmarshal method is fully implemented
 		l.ID, err = uuid.Parse(id)
 		if err != nil {
 			span.RecordError(err)

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -845,36 +845,6 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 		return
 	}
 
-	for id, ldata := range raw {
-		ldata["id"] = []string{id}
-		l := model.Location{}
-		if err := form.Unmarshal(ldata, &l); err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "could not parse other location")
-			p.logger.ErrorContext(ctx, "could not parse other location", "error", err)
-			continue
-		}
-		var err error
-		// INFO: workaround(l.ID) until Unmarshal method is fully implemented
-		l.ID, err = uuid.Parse(id)
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "invalid uuid")
-			p.logger.ErrorContext(ctx, "invalid uuid", "error", err)
-			continue
-		}
-		for i := 0; i < len(e.Airports); i++ {
-			if l.ID == e.Airports[i].ID {
-				e.Airports[i] = &l
-			}
-		}
-		for i := 0; i < len(e.Hotels); i++ {
-			if l.ID == e.Hotels[i].ID {
-				e.Hotels[i] = &l
-			}
-		}
-	}
-
 	if err := p.eStore.UpdateEvent(ctx, e); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "could not update event")

--- a/intern/server/templates/handler.go
+++ b/intern/server/templates/handler.go
@@ -845,7 +845,6 @@ func (p *GuestHandler) UpdateEvent(c *gin.Context) {
 		return
 	}
 
-	fmt.Println(raw)
 	for id, ldata := range raw {
 		ldata["id"] = []string{id}
 		l := model.Location{}


### PR DESCRIPTION
- resolves #72 

Seems like while iterating through airports & hotels they got the `model.Location` assigned.
But the form-data is only unmarshalled into the model. 
Therefore it doesn't get assigned with the correct uuid, but instead gets the uuid of the empty `model.Location`.

Just additionally assigning should solve this problem, otherwise you could also parse the UUID directly into the `model.Location` (line 857).