### PR TITLE
some changes due to templ preparation

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -77,6 +77,9 @@ jobs:
         with:
           go-version: ${{ fromJSON(needs.go-versions.outputs.version) }}
 
+      - name: Install tools format
+        run: make tools
+
       - name: Check format
         run: make check-fmt
 
@@ -108,11 +111,11 @@ jobs:
 
       - name: Test Go-version @version
         if: startsWith( matrix.go-version , needs.go-versions.outputs.version )
-        run: make gotest 
+        run: make gotest
 
       - name: Test Go-version @latest
         if: startsWith( matrix.go-version , needs.go-versions.outputs.latest )
-        run: make gotest 
+        run: make gotest
 
   build:
     name: Build
@@ -128,6 +131,8 @@ jobs:
         with:
           go-version: ${{ fromJSON(needs.go-versions.outputs.version) }}
 
+      - name: Install Tools
+        run: make tools
+
       - name: Build
         run: make build
-

--- a/Makefile
+++ b/Makefile
@@ -5,22 +5,26 @@ $(TOOLS_DIR):
 	mkdir -p $@
 
 # Funcs
-
 .PHONY: check-fmt
-check-fmt: gofmt
+check-fmt: fmt
 	@git diff -s --exit-code *.go || (echo "Build failed: a go file is not formated correctly. Run 'make fmt' and update your PR." && exit 1)
 
-.PHONY: gofmt
-gofmt:
+.PHONY: fmt
+fmt:
 	go fmt ./...
+	$(TEMPL) fmt .
 
 .PHONY: govet
 govet:
 	go vet ./...
 
 .PHONY: build
-build:
+build: generate
 	go build -v -o $(LETS_PARTY) $(ROOT_DIR)/cmd/server/main.go
+
+.PHONY: generate
+generate:
+	$(TEMPL) generate
 
 .PHONY: compilecheck
 compilecheck:
@@ -28,7 +32,7 @@ compilecheck:
 	go build -v ./...
 
 .PHONY: run
-run: gofmt build
+run: fmt build
 	$(LETS_PARTY)
 
 .PHONY: gotest
@@ -37,7 +41,7 @@ gotest:
 	go test -v ./... -failfast
 
 .PHONY: localtest
-localtest: gofmt govet check-fmt
+localtest: fmt govet check-fmt
 	$(GO_ENV)
 	go test -v ./... -failfast
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -8,16 +8,17 @@ ALL_GO_FILES=$(shell find $(ROOT_DIR) -type f -name "*.go")
 
 # Set tool-paths for easier access
 LINT := $(TOOLS_DIR)/golangci-lint
+TEMPL := $(TOOLS_DIR)/templ
 
 # Env vars
 GO_ENV=$(shell CGO_ENABLED=0)
 
 # Versioning
-GO_VERSION=1.21
+GO_VERSION=1.22
 GOLINT_VERSION=v1.57.2
 TEMPL_VERSION=v0.2.680
 
 # Licenseheader
-LICENSEHEAD_FIRST_LINE := // Copyright (C) 2024 the lets-party maintainers
+LICENSEHEAD_FIRST_LINE := // Copyright (C) 2024 the quixsi maintainers
 LICENSEHEAD_SECOND_LINE := // See root-dir/LICENSE for more information
 

--- a/cmd/convert/main.go
+++ b/cmd/convert/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package main

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package main

--- a/internal/db/event_store.go
+++ b/internal/db/event_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package db

--- a/internal/db/guest_store.go
+++ b/internal/db/guest_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package db

--- a/internal/db/invitation_store.go
+++ b/internal/db/invitation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package db

--- a/internal/db/jsondb/event_store.go
+++ b/internal/db/jsondb/event_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package jsondb

--- a/internal/db/jsondb/guest_store.go
+++ b/internal/db/jsondb/guest_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package jsondb

--- a/internal/db/jsondb/invitation_store.go
+++ b/internal/db/jsondb/invitation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package jsondb

--- a/internal/db/jsondb/tracing.go
+++ b/internal/db/jsondb/tracing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package jsondb

--- a/internal/db/jsondb/translation_store.go
+++ b/internal/db/jsondb/translation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package jsondb

--- a/internal/db/kvdb/event_store.go
+++ b/internal/db/kvdb/event_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package kvdb

--- a/internal/db/kvdb/guest_store.go
+++ b/internal/db/kvdb/guest_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package kvdb

--- a/internal/db/kvdb/invitation_store.go
+++ b/internal/db/kvdb/invitation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package kvdb

--- a/internal/db/kvdb/tracing.go
+++ b/internal/db/kvdb/tracing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package kvdb

--- a/internal/db/kvdb/translation_store.go
+++ b/internal/db/kvdb/translation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package kvdb

--- a/internal/db/translation_store.go
+++ b/internal/db/translation_store.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package db

--- a/internal/model/error.go
+++ b/internal/model/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/model/guest.go
+++ b/internal/model/guest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/model/invitation.go
+++ b/internal/model/invitation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/model/invitation_test.go
+++ b/internal/model/invitation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/model/translation.go
+++ b/internal/model/translation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package model

--- a/internal/parser/form/form.go
+++ b/internal/parser/form/form.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package form

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package server

--- a/internal/server/templates/handler.go
+++ b/internal/server/templates/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package templates

--- a/internal/server/templates/tracing.go
+++ b/internal/server/templates/tracing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package templates

--- a/internal/server/tracing.go
+++ b/internal/server/tracing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 the lets-party maintainers
+// Copyright (C) 2024 the quixsi maintainers
 // See root-dir/LICENSE for more information
 
 package server


### PR DESCRIPTION
 - added path to local `templ`
 - added `templ fmt` to `make fmt`
 - added `make generate` for templ files
 - set `GO_VERSION` to 1.22
 - changed licenseheader

EDIT: maybe we should consider reworking CI to just get tools once and be able to reuse them in every job